### PR TITLE
Add issue templates for liner codes in excel form

### DIFF
--- a/.github/ISSUE_TEMPLATE/liner-code-data-change-request-excel.yaml
+++ b/.github/ISSUE_TEMPLATE/liner-code-data-change-request-excel.yaml
@@ -1,7 +1,7 @@
 name: Liner code data change request (Excel)
 description: This template is used to request liner code data changes from excel form
 title: 'Liner code data change request: [Code]'
-labels: [ "data", "liner-code" ]
+labels: [ "data", "liner-code", 'format-excel' ]
 assignees: 'jasmindroenner-smdg'
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/liner-code-data-change-request-excel.yaml
+++ b/.github/ISSUE_TEMPLATE/liner-code-data-change-request-excel.yaml
@@ -1,0 +1,45 @@
+name: Liner code data change request (Excel)
+description: This template is used to request liner code data changes from excel form
+title: 'Liner code data change request: [Code]'
+labels: [ "data", "liner-code" ]
+assignees: 'jasmindroenner-smdg'
+body:
+  - type: markdown
+    attributes:
+      value: |
+        *Please note that the data provided below is considered public, do not include any sensitive information.*
+  - type: dropdown
+    id: change_type
+    attributes:
+      label: "Change Type"
+      description: Type of change to be made
+      options:
+        - "Add"
+        - "Update"
+        - "Delete"
+    validations:
+      required: true
+  - type: input
+    id: requester
+    attributes:
+      label: "Requester"
+      description: Entity requesting the change
+      placeholder: "Example: Maersk"
+    validations:
+      required: true
+  - type: input
+    id: liner_code
+    attributes:
+      label: "Liner code"
+      description: Code of the liner
+      placeholder: "Example: MSK"
+    validations:
+      required: true
+  - type: textarea
+    id: excel_file
+    attributes:
+      label: "Form attachment"
+      description: Form Attachment
+      placeholder: "Example: Click paperclip icon to attach the form in excel format"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/liner-code-data-change-request.yaml
+++ b/.github/ISSUE_TEMPLATE/liner-code-data-change-request.yaml
@@ -2,8 +2,12 @@ name: Liner code data change request
 description: This template is used to request liner code data changes
 title: 'Liner code data change request: [Code]'
 labels: [ "data", "liner-code" ]
-assignees: 'data-reviewers'
+assignees: 'jasmindroenner-smdg'
 body:
+  - type: markdown
+    attributes:
+      value: |
+        *Please note that the data provided below is considered public, do not include any sensitive information.*
   - type: dropdown
     id: change_type
     attributes:


### PR DESCRIPTION
# Description

## Why

We would like the user/data reviewers to receive and handle the old excel forms as well.

## What

- Added a template form for handling email submitted change requests in excel format

## What data has been changed

Mark 'x' for data pieces that has been changed

Data:

- [ ] Liner information has been changed

Development:

- [ ] Api solution has been changed
- [ ] Cli solution has been changed
- [x] Other
