### PR TITLE
release: Adjusted release triggers

### DIFF
--- a/.github/workflows/liner-code-release.yaml
+++ b/.github/workflows/liner-code-release.yaml
@@ -1,14 +1,12 @@
 name: Liner Codes - Release Excel #${{ github.run_number }}
 
 on:
-  workflow_dispatch: 
-    inputs:
-      dataset:
-        type: choice
-        required: true
-        options:
-          - liner-codes
-        default: 'liner-codes'
+  push:
+    branches:
+      - main
+    paths:
+      - data/liner-codes/**/*
+  workflow_dispatch:
 
 env:
   project: src/cli/SmdgCli/SmdgCli.csproj


### PR DESCRIPTION
# Description

## Why

The automatic release should run when data is pushed to liner codes

## What

- trigger adjusted for release workflow 

## What data has been changed

Mark 'x' for data pieces that has been changed

Data:

- [ ] Liner information has been changed

Development:

- [ ] Api solution has been changed
- [x] Cli solution has been changed
- [ ] Other
