### PR TITLE
Updated liner code validations

### DIFF
--- a/src/cli/SmdgCli.Test/Schemas/Liners/LinerCodeIndexValidatorTests.cs
+++ b/src/cli/SmdgCli.Test/Schemas/Liners/LinerCodeIndexValidatorTests.cs
@@ -23,7 +23,7 @@ public class LinerCodeIndexValidatorTests
             .With(x => x.LinerCodeFiles,
                 _fixture
                     .CreateMany<string>()
-                    .Select(c => c.Substring(0, 3)))
+                    .Select(c => c.Substring(0, 3) + ".json"))
             .Create();
 
         // Act
@@ -89,7 +89,7 @@ public class LinerCodeIndexValidatorTests
     {
         // Arrange
         var linerCodeIndex = _fixture.Build<LinerCodeIndex>()
-            .With(x => x.LinerCodeFiles, new List<string> { "1234" })
+            .With(x => x.LinerCodeFiles, new List<string> { "1234.json" })
             .Create();
 
         // Act
@@ -98,6 +98,6 @@ public class LinerCodeIndexValidatorTests
         // Assert
         result
             .ShouldHaveValidationErrorFor(x => x.LinerCodeFiles)
-            .WithErrorMessage("Liner code must be at no more than 3 characters long.");
+            .WithErrorMessage("Liner code file name must be no more than 8 characters long.");
     }
 }

--- a/src/cli/SmdgCli.Test/Schemas/Liners/LinerCodeValidatorTests.cs
+++ b/src/cli/SmdgCli.Test/Schemas/Liners/LinerCodeValidatorTests.cs
@@ -53,7 +53,7 @@ public class LinerCodeValidatorTests
     {
         // Arrange
         var linerCode = _fixture.Build<LinerCode>()
-            .With(x => x.LinerCodeVersion, "123")
+            .With(x => x.LinerCodeVersion, "1234")
             .Create();
 
         // Act
@@ -62,6 +62,6 @@ public class LinerCodeValidatorTests
         // Assert
         result
             .ShouldHaveValidationErrorFor(x => x.LinerCodeVersion)
-            .WithErrorMessage("Liner Code Version must be 2 characters long");
+            .WithErrorMessage("Liner Code Version must be 3 characters long");
     }
 }

--- a/src/cli/SmdgCli.Test/Schemas/Liners/LinerCodeValidatorTests.cs
+++ b/src/cli/SmdgCli.Test/Schemas/Liners/LinerCodeValidatorTests.cs
@@ -62,6 +62,6 @@ public class LinerCodeValidatorTests
         // Assert
         result
             .ShouldHaveValidationErrorFor(x => x.LinerCodeVersion)
-            .WithErrorMessage("Liner Code Version must be 3 characters long");
+            .WithErrorMessage("Liner Code Version must be maximum 3 characters long");
     }
 }

--- a/src/cli/SmdgCli/Schemas/Liners/LinerCodeValidator.cs
+++ b/src/cli/SmdgCli/Schemas/Liners/LinerCodeValidator.cs
@@ -9,14 +9,14 @@ public class LinerCodeValidator : AbstractValidator<LinerCode>
         RuleFor(x => x.LinerCodeVersion)
             .NotEmpty()
             .WithMessage("Liner Code Version is required")
-            .MaximumLength(2)
+            .MaximumLength(3)
             .WithMessage("Liner Code Version must be 2 characters long");
 
         RuleFor(x => x.LinerSmdgCode)
             .NotEmpty()
             .WithMessage("Liner Code is required")
-            .MaximumLength(3)
-            .WithMessage("Liner Code must be 3 characters long");
+            .Length(3)
+            .WithMessage("Liner Code must be exactly 3 characters long");
 
         RuleFor(x => x.LinerName)
             .NotEmpty()

--- a/src/cli/SmdgCli/Schemas/Liners/LinerCodeValidator.cs
+++ b/src/cli/SmdgCli/Schemas/Liners/LinerCodeValidator.cs
@@ -10,7 +10,7 @@ public class LinerCodeValidator : AbstractValidator<LinerCode>
             .NotEmpty()
             .WithMessage("Liner Code Version is required")
             .MaximumLength(3)
-            .WithMessage("Liner Code Version must be 3 characters long");
+            .WithMessage("Liner Code Version must be maximum 3 characters long");
 
         RuleFor(x => x.LinerSmdgCode)
             .NotEmpty()

--- a/src/cli/SmdgCli/Schemas/Liners/LinerCodeValidator.cs
+++ b/src/cli/SmdgCli/Schemas/Liners/LinerCodeValidator.cs
@@ -10,7 +10,7 @@ public class LinerCodeValidator : AbstractValidator<LinerCode>
             .NotEmpty()
             .WithMessage("Liner Code Version is required")
             .MaximumLength(3)
-            .WithMessage("Liner Code Version must be 2 characters long");
+            .WithMessage("Liner Code Version must be 3 characters long");
 
         RuleFor(x => x.LinerSmdgCode)
             .NotEmpty()


### PR DESCRIPTION
# Description

## Why

The liner code needs to be exactly 3 char long

## What

Changed validation to match the requirement

## What data has been changed

Mark 'x' for data pieces that has been changed

Data:

- [ ] Liner information has been changed

Development:

- [ ] Api solution has been changed
- [x] Cli solution has been changed
- [ ] Other
