### PR TITLE
Rebuild _combined.json to match individual liner code files

### DIFF
--- a/data/liner-codes/_combined.json
+++ b/data/liner-codes/_combined.json
@@ -3,6 +3,123 @@
     "isActive": true,
     "codeStatus": "Active",
     "linerCodeVersion": "V1",
+    "linerSMDGCode": "AAA",
+    "linerName": "AWATAC  Singapore  Pte  Ltd",
+    "carrierType": "NVOCC",
+    "parentCompany": "AWATAC Container  Line",
+    "address": "105,CECIL STREET ,#16-01,( SUITE -1614 ),THE  OCTAGON ,SINGAPORE -069534",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "http://www.awatacgroup.com/",
+    "remarks": "",
+    "validFrom": "2022-05-30",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2022-05-30",
+        "updateRequestedBy": "AWATAC",
+        "reason": "new request",
+        "changedFields": [],
+        "linkedLinerCode": "",
+        "comments": "requested by AWATAC"
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
+    "linerSMDGCode": "AAL",
+    "linerName": "Austral Asia Line",
+    "carrierType": "UNKNOWN",
+    "parentCompany": "",
+    "address": "9 Temasek Boulevard, #20-01 Suntec Tower 2, Singapore 038989",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "http://aalshipping.com",
+    "remarks": "",
+    "validFrom": "2003-09-01",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2021-01-01",
+        "updateRequestedBy": null,
+        "reason": "initial change",
+        "changedFields": [],
+        "linkedLinerCode": "",
+        "comments": "This change was not tracked in excel and it was added by GitHub workflow."
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
+    "linerSMDGCode": "AAS",
+    "linerName": "ANDAMAN ASIA SHIPPING LINE LIMITED",
+    "carrierType": "NVOCC",
+    "parentCompany": "",
+    "address": "R00M 70, 7/F WOON LEE COMMERCIAL  BUILDING 7-9 AUSTIN AVE TST KOWLOON HONG KONG              ",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "Not available",
+    "remarks": "",
+    "validFrom": "2026-02-12",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2026-02-13",
+        "updateRequestedBy": "ANDAMAN ASIA SHIPPING LINE LIMITED",
+        "reason": "",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": ""
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
     "linerSMDGCode": "ACL",
     "linerName": "Atlantic Container Line",
     "carrierType": "VOCC",
@@ -864,6 +981,45 @@
         "changedFields": [],
         "linkedLinerCode": "",
         "comments": "This change was not tracked in excel and it was added by GitHub workflow."
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
+    "linerSMDGCode": "BAA",
+    "linerName": "Bulk Oil & Liquid Transport Pte Ltd",
+    "carrierType": "NVOCC",
+    "parentCompany": "",
+    "address": "60 Paya Lebar Road, #05-38 Paya Lebar Square, Singapore 409051",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "www.bolt-tanks.com",
+    "remarks": "",
+    "validFrom": "2023-07-17",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2023-07-17",
+        "updateRequestedBy": "Bulk Oil & Liquid Transport Pte Ltd",
+        "reason": "new request",
+        "changedFields": [],
+        "linkedLinerCode": "",
+        "comments": "requested by Bulk Oil & Liquid Transport Pte Ltd"
       }
     ]
   },
@@ -1888,45 +2044,6 @@
         "changedFields": [],
         "linkedLinerCode": "",
         "comments": "requested by BVC"
-      }
-    ]
-  },
-  {
-    "isActive": true,
-    "codeStatus": "Active",
-    "linerCodeVersion": "V1",
-    "linerSMDGCode": "BAA",
-    "linerName": "Bulk Oil & Liquid Transport Pte Ltd",
-    "carrierType": "NVOCC",
-    "parentCompany": "",
-    "address": "60 Paya Lebar Road, #05-38 Paya Lebar Square, Singapore 409051",
-    "addressLocation": {
-      "UnLocode": null,
-      "UnCountryCode": null,
-      "address": {
-        "street": null,
-        "streetNumber": null,
-        "floor": null,
-        "postCode": null,
-        "city": null,
-        "state": null,
-        "country": null
-      }
-    },
-    "website": "www.bolt-tanks.com",
-    "remarks": "",
-    "validFrom": "2023-07-17",
-    "validTo": null,
-    "changeLogs": [
-      {
-        "actionCode": "Added",
-        "linerCodeVersion": "V1",
-        "lastUpdateDate": "2023-07-17",
-        "updateRequestedBy": "Bulk Oil & Liquid Transport Pte Ltd",
-        "reason": "new request",
-        "changedFields": [],
-        "linkedLinerCode": "",
-        "comments": "requested by Bulk Oil & Liquid Transport Pte Ltd"
       }
     ]
   },
@@ -14161,123 +14278,6 @@
         "changedFields": [],
         "linkedLinerCode": "",
         "comments": "Correction sent by email from ZIM"
-      }
-    ]
-  },
-  {
-    "isActive": true,
-    "codeStatus": "Active",
-    "linerCodeVersion": "V1",
-    "linerSMDGCode": "AAA",
-    "linerName": "AWATAC  Singapore  Pte  Ltd",
-    "carrierType": "NVOCC",
-    "parentCompany": "AWATAC Container  Line",
-    "address": "105,CECIL STREET ,#16-01,( SUITE -1614 ),THE  OCTAGON ,SINGAPORE -069534",
-    "addressLocation": {
-      "UnLocode": null,
-      "UnCountryCode": null,
-      "address": {
-        "street": null,
-        "streetNumber": null,
-        "floor": null,
-        "postCode": null,
-        "city": null,
-        "state": null,
-        "country": null
-      }
-    },
-    "website": "http://www.awatacgroup.com/",
-    "remarks": "",
-    "validFrom": "2022-05-30",
-    "validTo": null,
-    "changeLogs": [
-      {
-        "actionCode": "Added",
-        "linerCodeVersion": "V1",
-        "lastUpdateDate": "2022-05-30",
-        "updateRequestedBy": "AWATAC",
-        "reason": "new request",
-        "changedFields": [],
-        "linkedLinerCode": "",
-        "comments": "requested by AWATAC"
-      }
-    ]
-  },
-  {
-    "isActive": true,
-    "codeStatus": "Active",
-    "linerCodeVersion": "V1",
-    "linerSMDGCode": "AAL",
-    "linerName": "Austral Asia Line",
-    "carrierType": "UNKNOWN",
-    "parentCompany": "",
-    "address": "9 Temasek Boulevard, #20-01 Suntec Tower 2, Singapore 038989",
-    "addressLocation": {
-      "UnLocode": null,
-      "UnCountryCode": null,
-      "address": {
-        "street": null,
-        "streetNumber": null,
-        "floor": null,
-        "postCode": null,
-        "city": null,
-        "state": null,
-        "country": null
-      }
-    },
-    "website": "http://aalshipping.com",
-    "remarks": "",
-    "validFrom": "2003-09-01",
-    "validTo": null,
-    "changeLogs": [
-      {
-        "actionCode": "Added",
-        "linerCodeVersion": "V1",
-        "lastUpdateDate": "2021-01-01",
-        "updateRequestedBy": null,
-        "reason": "initial change",
-        "changedFields": [],
-        "linkedLinerCode": "",
-        "comments": "This change was not tracked in excel and it was added by GitHub workflow."
-      }
-    ]
-  },
-  {
-    "isActive": true,
-    "codeStatus": "Active",
-    "linerCodeVersion": "V1",
-    "linerSMDGCode": "AAS",
-    "linerName": "ANDAMAN ASIA SHIPPING LINE LIMITED",
-    "carrierType": "NVOCC",
-    "parentCompany": "",
-    "address": "R00M 70, 7/F WOON LEE COMMERCIAL  BUILDING 7-9 AUSTIN AVE TST KOWLOON HONG KONG              ",
-    "addressLocation": {
-      "UnLocode": null,
-      "UnCountryCode": null,
-      "address": {
-        "street": null,
-        "streetNumber": null,
-        "floor": null,
-        "postCode": null,
-        "city": null,
-        "state": null,
-        "country": null
-      }
-    },
-    "website": "Not available",
-    "remarks": "",
-    "validFrom": "2026-02-12",
-    "validTo": null,
-    "changeLogs": [
-      {
-        "actionCode": "Added",
-        "linerCodeVersion": "V1",
-        "lastUpdateDate": "2026-02-13",
-        "updateRequestedBy": "ANDAMAN ASIA SHIPPING LINE LIMITED",
-        "reason": "",
-        "changedFields": [],
-        "linkedLinerCode": null,
-        "comments": ""
       }
     ]
   }

--- a/data/liner-codes/_combined.json
+++ b/data/liner-codes/_combined.json
@@ -3,123 +3,6 @@
     "isActive": true,
     "codeStatus": "Active",
     "linerCodeVersion": "V1",
-    "linerSMDGCode": "AAA",
-    "linerName": "AWATAC  Singapore  Pte  Ltd",
-    "carrierType": "NVOCC",
-    "parentCompany": "AWATAC Container  Line",
-    "address": "105,CECIL STREET ,#16-01,( SUITE -1614 ),THE  OCTAGON ,SINGAPORE -069534",
-    "addressLocation": {
-      "UnLocode": null,
-      "UnCountryCode": null,
-      "address": {
-        "street": null,
-        "streetNumber": null,
-        "floor": null,
-        "postCode": null,
-        "city": null,
-        "state": null,
-        "country": null
-      }
-    },
-    "website": "http://www.awatacgroup.com/",
-    "remarks": "",
-    "validFrom": "2022-05-30",
-    "validTo": null,
-    "changeLogs": [
-      {
-        "actionCode": "Added",
-        "linerCodeVersion": "V1",
-        "lastUpdateDate": "2022-05-30",
-        "updateRequestedBy": "AWATAC",
-        "reason": "new request",
-        "changedFields": [],
-        "linkedLinerCode": "",
-        "comments": "requested by AWATAC"
-      }
-    ]
-  },
-  {
-    "isActive": true,
-    "codeStatus": "Active",
-    "linerCodeVersion": "V1",
-    "linerSMDGCode": "AAL",
-    "linerName": "Austral Asia Line",
-    "carrierType": "UNKNOWN",
-    "parentCompany": "",
-    "address": "9 Temasek Boulevard, #20-01 Suntec Tower 2, Singapore 038989",
-    "addressLocation": {
-      "UnLocode": null,
-      "UnCountryCode": null,
-      "address": {
-        "street": null,
-        "streetNumber": null,
-        "floor": null,
-        "postCode": null,
-        "city": null,
-        "state": null,
-        "country": null
-      }
-    },
-    "website": "http://aalshipping.com",
-    "remarks": "",
-    "validFrom": "2003-09-01",
-    "validTo": null,
-    "changeLogs": [
-      {
-        "actionCode": "Added",
-        "linerCodeVersion": "V1",
-        "lastUpdateDate": "2021-01-01",
-        "updateRequestedBy": null,
-        "reason": "initial change",
-        "changedFields": [],
-        "linkedLinerCode": "",
-        "comments": "This change was not tracked in excel and it was added by GitHub workflow."
-      }
-    ]
-  },
-  {
-    "isActive": true,
-    "codeStatus": "Active",
-    "linerCodeVersion": "V1",
-    "linerSMDGCode": "AAS",
-    "linerName": "ANDAMAN ASIA SHIPPING LINE LIMITED",
-    "carrierType": "NVOCC",
-    "parentCompany": "",
-    "address": "R00M 70, 7/F WOON LEE COMMERCIAL  BUILDING 7-9 AUSTIN AVE TST KOWLOON HONG KONG              ",
-    "addressLocation": {
-      "UnLocode": null,
-      "UnCountryCode": null,
-      "address": {
-        "street": null,
-        "streetNumber": null,
-        "floor": null,
-        "postCode": null,
-        "city": null,
-        "state": null,
-        "country": null
-      }
-    },
-    "website": "Not available",
-    "remarks": "",
-    "validFrom": "2026-02-12",
-    "validTo": null,
-    "changeLogs": [
-      {
-        "actionCode": "Added",
-        "linerCodeVersion": "V1",
-        "lastUpdateDate": "2026-02-13",
-        "updateRequestedBy": "ANDAMAN ASIA SHIPPING LINE LIMITED",
-        "reason": "",
-        "changedFields": [],
-        "linkedLinerCode": null,
-        "comments": ""
-      }
-    ]
-  },
-  {
-    "isActive": true,
-    "codeStatus": "Active",
-    "linerCodeVersion": "V1",
     "linerSMDGCode": "ACL",
     "linerName": "Atlantic Container Line",
     "carrierType": "VOCC",
@@ -981,45 +864,6 @@
         "changedFields": [],
         "linkedLinerCode": "",
         "comments": "This change was not tracked in excel and it was added by GitHub workflow."
-      }
-    ]
-  },
-  {
-    "isActive": true,
-    "codeStatus": "Active",
-    "linerCodeVersion": "V1",
-    "linerSMDGCode": "BAA",
-    "linerName": "Bulk Oil & Liquid Transport Pte Ltd",
-    "carrierType": "NVOCC",
-    "parentCompany": "",
-    "address": "60 Paya Lebar Road, #05-38 Paya Lebar Square, Singapore 409051",
-    "addressLocation": {
-      "UnLocode": null,
-      "UnCountryCode": null,
-      "address": {
-        "street": null,
-        "streetNumber": null,
-        "floor": null,
-        "postCode": null,
-        "city": null,
-        "state": null,
-        "country": null
-      }
-    },
-    "website": "www.bolt-tanks.com",
-    "remarks": "",
-    "validFrom": "2023-07-17",
-    "validTo": null,
-    "changeLogs": [
-      {
-        "actionCode": "Added",
-        "linerCodeVersion": "V1",
-        "lastUpdateDate": "2023-07-17",
-        "updateRequestedBy": "Bulk Oil & Liquid Transport Pte Ltd",
-        "reason": "new request",
-        "changedFields": [],
-        "linkedLinerCode": "",
-        "comments": "requested by Bulk Oil & Liquid Transport Pte Ltd"
       }
     ]
   },
@@ -2051,6 +1895,45 @@
     "isActive": true,
     "codeStatus": "Active",
     "linerCodeVersion": "V1",
+    "linerSMDGCode": "BAA",
+    "linerName": "Bulk Oil & Liquid Transport Pte Ltd",
+    "carrierType": "NVOCC",
+    "parentCompany": "",
+    "address": "60 Paya Lebar Road, #05-38 Paya Lebar Square, Singapore 409051",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "www.bolt-tanks.com",
+    "remarks": "",
+    "validFrom": "2023-07-17",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2023-07-17",
+        "updateRequestedBy": "Bulk Oil & Liquid Transport Pte Ltd",
+        "reason": "new request",
+        "changedFields": [],
+        "linkedLinerCode": "",
+        "comments": "requested by Bulk Oil & Liquid Transport Pte Ltd"
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
     "linerSMDGCode": "CAE",
     "linerName": "Caerus Shipping",
     "carrierType": "VOCC",
@@ -2889,28 +2772,28 @@
   {
     "isActive": true,
     "codeStatus": "Active",
-    "linerCodeVersion": "V1",
+    "linerCodeVersion": "V2",
     "linerSMDGCode": "COE",
-    "linerName": "COSCO SHIPPING Lines (Europe) GmbH",
-    "carrierType": "UNKNOWN",
-    "parentCompany": "COS",
+    "linerName": "Diamond Line GmbH",
+    "carrierType": "VOCC",
+    "parentCompany": "COSCO SHIPPING Lines (Europe) GmbH",
     "address": "Logistics service, Am Sandtorkai 60 ·",
     "addressLocation": {
-      "UnLocode": null,
-      "UnCountryCode": null,
+      "UnLocode": "HAM",
+      "UnCountryCode": "DE",
       "address": {
-        "street": null,
-        "streetNumber": null,
+        "street": "Herrengraben",
+        "streetNumber": "74",
         "floor": null,
-        "postCode": null,
-        "city": null,
+        "postCode": "20459",
+        "city": "Hamburg",
         "state": null,
-        "country": null
+        "country": "Germany"
       }
     },
-    "website": "http://en.coscocs.com/",
+    "website": "https://world.lines.coscoshipping.com/europe/en/home",
     "remarks": "",
-    "validFrom": "2015-04-08",
+    "validFrom": "2026-05-29",
     "validTo": null,
     "changeLogs": [
       {
@@ -2922,6 +2805,16 @@
         "changedFields": [],
         "linkedLinerCode": "",
         "comments": "This change was not tracked in excel and it was added by GitHub workflow."
+      },
+      {
+        "actionCode": "Updated",
+        "linerCodeVersion": "V2",
+        "lastUpdateDate": "2026-06-15",
+        "updateRequestedBy": "COSCO SHIPPING Lines (Europe) GmbH",
+        "reason": "vessels operated by Diamond Line GmbH instead of COSCO SHIPPING Lines (Europe) GmbH",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": null
       }
     ]
   },
@@ -5319,11 +5212,11 @@
     "isActive": true,
     "codeStatus": "Active",
     "linerCodeVersion": "V1",
-    "linerSMDGCode": "GUA",
-    "linerName": "Guaran Feeder",
-    "carrierType": "UNKNOWN",
+    "linerSMDGCode": "GTL",
+    "linerName": "GT SHIPPING AGENCY L.L.C.SP",
+    "carrierType": "VOCC",
     "parentCompany": "",
-    "address": "Asuncion",
+    "address": "Gulftainer, Buhaira Corniche, SARH AL EMARAT, 43rd Floor, Sharjah, United Arab Emirates",
     "addressLocation": {
       "UnLocode": null,
       "UnCountryCode": null,
@@ -5337,7 +5230,46 @@
         "country": null
       }
     },
-    "website": "",
+    "website": "https://www.gulftainer.com",
+    "remarks": "",
+    "validFrom": "2023-08-03",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2026-07-16",
+        "updateRequestedBy": "GT SHIPPING AGENCY L.L.C.SP",
+        "reason": "",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": ""
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V2",
+    "linerSMDGCode": "GUA",
+    "linerName": "Guaran Feeder",
+    "carrierType": "VOCC",
+    "parentCompany": "",
+    "address": "Asuncion",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": "Av. Artigas",
+        "streetNumber": "3443",
+        "floor": null,
+        "postCode": null,
+        "city": "Asunción",
+        "state": null,
+        "country": "Paraguay"
+      }
+    },
+    "website": "www.guaranfeeder.com",
     "remarks": "",
     "validFrom": "2020-09-04",
     "validTo": null,
@@ -5351,6 +5283,16 @@
         "changedFields": [],
         "linkedLinerCode": "",
         "comments": "This change was not tracked in excel and it was added by GitHub workflow."
+      },
+      {
+        "actionCode": "Updated",
+        "linerCodeVersion": "V2",
+        "lastUpdateDate": "2026-05-17",
+        "updateRequestedBy": "Guaran Feeder",
+        "reason": "additional information",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": null
       }
     ]
   },
@@ -6753,6 +6695,45 @@
     "isActive": true,
     "codeStatus": "Active",
     "linerCodeVersion": "V1",
+    "linerSMDGCode": "JHS",
+    "linerName": "JOIN HANDS SHIPPING LINE COMPANY LIMITED",
+    "carrierType": "NVOCC",
+    "parentCompany": "JHS",
+    "address": "WORK SHOP 60 3/F BLOCK A EAST SUN INDUSTRIAL CENTRE NO. 16 SHING YIP STREET KL,HONG KONG",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "www.kimberryline.com ",
+    "remarks": "",
+    "validFrom": "2026-03-06",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2026-03-06",
+        "updateRequestedBy": "JOIN HANDS SHIPPING LINE COMPANY LIMITED",
+        "reason": "",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": ""
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
     "linerSMDGCode": "JTK",
     "linerName": "P.T. Jasatama Kemasindo",
     "carrierType": "UNKNOWN",
@@ -6824,6 +6805,45 @@
         "changedFields": [],
         "linkedLinerCode": "",
         "comments": "This change was not tracked in excel and it was added by GitHub workflow."
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
+    "linerSMDGCode": "KLX",
+    "linerName": "KARTEN INTERNATIONAL LOGISTICS PTE LTD",
+    "carrierType": "NVOCC",
+    "parentCompany": "KARTEN",
+    "address": "Room 1149, Guangfa Building, South Dongmen Road, Luohu District, Shenzhen (China)",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "www.kartenlog.com",
+    "remarks": "",
+    "validFrom": "2026-03-27",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2026-04-01",
+        "updateRequestedBy": "KARTEN INTERNATIONAL LOGISTICS PTE LTD",
+        "reason": "",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": ""
       }
     ]
   },
@@ -10226,6 +10246,45 @@
     "isActive": true,
     "codeStatus": "Active",
     "linerCodeVersion": "V1",
+    "linerSMDGCode": "RAL",
+    "linerName": "Royal Arctic Line A/S",
+    "carrierType": "VOCC",
+    "parentCompany": "RAL",
+    "address": "Royal Arctic Line A/S, Aqqusinersuaq 52, Postboks 1580, 3900 Nuuk",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "https://www.RAL.dk",
+    "remarks": "",
+    "validFrom": "2026-04-17",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2026-05-17",
+        "updateRequestedBy": "Royal Arctic Line A/S",
+        "reason": "",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": ""
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
     "linerSMDGCode": "RCL",
     "linerName": "Regional Container Line",
     "carrierType": "UNKNOWN",
@@ -10414,6 +10473,45 @@
         "changedFields": [],
         "linkedLinerCode": "",
         "comments": "requested by Megastar (parent company)"
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
+    "linerSMDGCode": "RTS",
+    "linerName": "RTSB Line",
+    "carrierType": "NVOCC",
+    "parentCompany": "",
+    "address": "Industriestraße 24, 61381 Friedrichsdorf ",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "rtsb.group",
+    "remarks": "",
+    "validFrom": "2026-05-01",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2026-05-15",
+        "updateRequestedBy": "RTSB Line",
+        "reason": "",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": ""
       }
     ]
   },
@@ -10800,6 +10898,45 @@
         "linerCodeVersion": "V1",
         "lastUpdateDate": "2025-12-04",
         "updateRequestedBy": "Swift Flow Shipping Services",
+        "reason": "",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": ""
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
+    "linerSMDGCode": "SGB",
+    "linerName": "Seatrade Group B.V.",
+    "carrierType": "VOCC",
+    "parentCompany": "",
+    "address": "Graaf Engelbertlaan 75, 4837 DS Breda, Netherlands",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "www.seatrade.com",
+    "remarks": "",
+    "validFrom": "2026-04-08",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2026-04-19",
+        "updateRequestedBy": "Seatrade Group B.V.",
         "reason": "",
         "changedFields": [],
         "linkedLinerCode": null,
@@ -12831,6 +12968,45 @@
     "isActive": true,
     "codeStatus": "Active",
     "linerCodeVersion": "V1",
+    "linerSMDGCode": "TTQ",
+    "linerName": "TANKTAINER SHIPPING (S) PTE LTD ",
+    "carrierType": "NVOCC",
+    "parentCompany": "",
+    "address": "200 CANTONMENT ROAD, SOUTHPOINT #02-05, SINGAPORE 089763",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "",
+    "remarks": "",
+    "validFrom": "2026-04-01",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2026-04-19",
+        "updateRequestedBy": "TANKTAINER SHIPPING (S) PTE LTD",
+        "reason": "",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": ""
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
     "linerSMDGCode": "TTR",
     "linerName": "Tru-Trans Malaysia",
     "carrierType": "UNKNOWN",
@@ -13985,6 +14161,123 @@
         "changedFields": [],
         "linkedLinerCode": "",
         "comments": "Correction sent by email from ZIM"
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
+    "linerSMDGCode": "AAA",
+    "linerName": "AWATAC  Singapore  Pte  Ltd",
+    "carrierType": "NVOCC",
+    "parentCompany": "AWATAC Container  Line",
+    "address": "105,CECIL STREET ,#16-01,( SUITE -1614 ),THE  OCTAGON ,SINGAPORE -069534",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "http://www.awatacgroup.com/",
+    "remarks": "",
+    "validFrom": "2022-05-30",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2022-05-30",
+        "updateRequestedBy": "AWATAC",
+        "reason": "new request",
+        "changedFields": [],
+        "linkedLinerCode": "",
+        "comments": "requested by AWATAC"
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
+    "linerSMDGCode": "AAL",
+    "linerName": "Austral Asia Line",
+    "carrierType": "UNKNOWN",
+    "parentCompany": "",
+    "address": "9 Temasek Boulevard, #20-01 Suntec Tower 2, Singapore 038989",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "http://aalshipping.com",
+    "remarks": "",
+    "validFrom": "2003-09-01",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2021-01-01",
+        "updateRequestedBy": null,
+        "reason": "initial change",
+        "changedFields": [],
+        "linkedLinerCode": "",
+        "comments": "This change was not tracked in excel and it was added by GitHub workflow."
+      }
+    ]
+  },
+  {
+    "isActive": true,
+    "codeStatus": "Active",
+    "linerCodeVersion": "V1",
+    "linerSMDGCode": "AAS",
+    "linerName": "ANDAMAN ASIA SHIPPING LINE LIMITED",
+    "carrierType": "NVOCC",
+    "parentCompany": "",
+    "address": "R00M 70, 7/F WOON LEE COMMERCIAL  BUILDING 7-9 AUSTIN AVE TST KOWLOON HONG KONG              ",
+    "addressLocation": {
+      "UnLocode": null,
+      "UnCountryCode": null,
+      "address": {
+        "street": null,
+        "streetNumber": null,
+        "floor": null,
+        "postCode": null,
+        "city": null,
+        "state": null,
+        "country": null
+      }
+    },
+    "website": "Not available",
+    "remarks": "",
+    "validFrom": "2026-02-12",
+    "validTo": null,
+    "changeLogs": [
+      {
+        "actionCode": "Added",
+        "linerCodeVersion": "V1",
+        "lastUpdateDate": "2026-02-13",
+        "updateRequestedBy": "ANDAMAN ASIA SHIPPING LINE LIMITED",
+        "reason": "",
+        "changedFields": [],
+        "linkedLinerCode": null,
+        "comments": ""
       }
     ]
   }


### PR DESCRIPTION
# Description

## Why

`data/liner-codes/_combined.json` had drifted out of sync with the per-code JSON files. This is the file published to `s3://dev-smdg-codelists-linercodes/_combined.json` and consumed downstream by the API, so the drift means several liner codes were missing or outdated for every consumer of the combined file.

It also broke the release pipeline: **`Liner Codes - Release Data` has failed on every push since 2026-03-03**, at the verify step with `There are un-synched changes on combined file`. Because that job gates `release-dataset`, no Excel release has been published since `20260303-49`.

## What

Regenerated the file with the repo's own tool:

```bash
dotnet run --project src/cli/SmdgCli/SmdgCli.csproj -- liner-codes pack combined -o data/liner-codes
```

This takes the combined file from **351 → 358 entries**, so it now matches all 358 individual source files exactly (verified: same code set, and every record byte-identical to its source file).

### Codes added to the combined file

| Code | Company | Status | Last change |
|---|---|---|---|
| GTL | GT SHIPPING AGENCY L.L.C.SP | Active | Added 2026-07-16 |
| JHS | JOIN HANDS SHIPPING LINE COMPANY LIMITED | Active | Added 2026-03-06 |
| KLX | KARTEN INTERNATIONAL LOGISTICS PTE LTD | Active | Added 2026-04-01 |
| RAL | Royal Arctic Line A/S | Active | Added 2026-05-17 |
| RTS | RTSB Line | Active | Added 2026-05-15 |
| SGB | Seatrade Group B.V. | Active | Added 2026-04-19 |
| TTQ | TANKTAINER SHIPPING (S) PTE LTD | Active | Added 2026-04-19 |

### Codes updated in the combined file

| Code | Company | Status | Last change |
|---|---|---|---|
| COE | Diamond Line GmbH (was "COSCO SHIPPING Lines (Europe) GmbH") | Active | Updated 2026-06-15 |
| GUA | Guaran Feeder | Active | Updated 2026-05-17 |

No codes are removed. Only `_combined.json` is touched — no per-code source file is modified.

## Root cause (not fixed here)

The rebuild is supposed to happen automatically in the `Liner Codes - Verify Data Changes` workflow, which runs on `pull_request` and commits "Rebuilding the combined liner codes file" to the PR branch.

That workflow has not run since 2026-03-02. The data PRs are opened by `peter-evans/create-pull-request` using `${{ github.token }}`, and GitHub does not trigger workflow runs for events created with `GITHUB_TOKEN`. PRs #156, #158, #160, #163, #166, #169, #171 and #173 therefore all merged with **zero checks**, and the repo has had zero `pull_request` events since 2026-04-01. Historically the rebuild only landed when someone happened to push an extra commit to the PR branch by hand (e.g. #152).

Suggested follow-up in a separate PR: move the `pack combined` step into the `Liner Codes - Process Issue` job so it runs *before* the PR is created, rather than depending on a `pull_request`-triggered workflow that a `GITHUB_TOKEN` PR cannot fire.

## What data has been changed

Data:
- [x] Liner information has been changed (combined file regenerated; no source records edited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nsp6hbD1GwWMGDPn3bSRB1